### PR TITLE
feat: support `inverted` list and grid view

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ More about the differences in `props` compared to React Native's FlatList are li
 | `numColumns`           | `numColumns`                |          |
 | `onEndReachedDelta`    | `onEndReachedThreshold`     |          |
 | `controller`           | ``                          |          |
+| `inverted`             | `inverted`                  |          |
 
 ### Basic setup
 The complete example is available here.
@@ -159,8 +160,8 @@ Examples are provided in `/example` folder.
       - [scrollToIndex](https://reactnative.dev/docs/flatlist#scrolltoindex)
       - [scrollToItem](https://reactnative.dev/docs/flatlist#scrolltoitem)
       - [scrollToOffset](https://reactnative.dev/docs/flatlist#scrolltooffset)
+- [x] Support [inverted](https://reactnative.dev/docs/flatlist#inverted)
 - [ ] Enhance `onEndReachedDelta` with similar to `onEndReachedThreshold`
-- [ ] Support [inverted](https://reactnative.dev/docs/flatlist#inverted)
 - [ ] Test coverage
 
 ## Additional information

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -1,6 +1,8 @@
 import 'package:flat_list_example/screens/flat_list_ex1.dart';
 import 'package:flat_list_example/screens/flat_list_ex2.dart';
 import 'package:flat_list_example/screens/flat_list_ex3.dart';
+import 'package:flat_list_example/screens/flat_list_ex4.dart';
+import 'package:flat_list_example/screens/flat_list_ex5.dart';
 import 'package:flat_list_example/screens/home.dart';
 import 'package:flutter/foundation.dart';
 
@@ -9,6 +11,8 @@ enum AppRoute {
   flatListEx1,
   flatListEx2,
   flatListEx3,
+  flatListEx4,
+  flatListEx5,
 }
 
 extension RouteName on AppRoute {
@@ -44,4 +48,6 @@ final routes = {
   AppRoute.flatListEx1.fullPath: (context) => const FlatListEx1(),
   AppRoute.flatListEx2.fullPath: (context) => const FlatListEx2(),
   AppRoute.flatListEx3.fullPath: (context) => const FlatListEx3(),
+  AppRoute.flatListEx4.fullPath: (context) => const FlatListEx4(),
+  AppRoute.flatListEx5.fullPath: (context) => const FlatListEx5(),
 };

--- a/example/lib/screens/flat_list_ex4.dart
+++ b/example/lib/screens/flat_list_ex4.dart
@@ -1,0 +1,57 @@
+import 'package:flat_list/flat_list.dart';
+import 'package:flat_list_example/common_views.dart';
+import 'package:flat_list_example/data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class FlatListEx4 extends HookWidget {
+  const FlatListEx4({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var items = useState(data);
+    var loading = useState(false);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Inverted ListView'),
+      ),
+      body: SafeArea(
+        child: FlatList(
+          inverted: true,
+          loading: loading.value,
+          onEndReached: () async {
+            loading.value = true;
+            await Future.delayed(const Duration(seconds: 2));
+            if (context.mounted) {
+              items.value += getMoreData();
+              loading.value = false;
+            }
+          },
+          onRefresh: () async {
+            await Future.delayed(const Duration(seconds: 2));
+
+            if (context.mounted) {
+              items.value = data;
+            }
+          },
+          listHeaderWidget: const Header(),
+          listFooterWidget: const Footer(),
+          listEmptyWidget: Container(
+            alignment: Alignment.center,
+            padding: const EdgeInsets.all(12),
+            child: const Text('List is empty!'),
+          ),
+          itemSeparatorWidget:
+              const Divider(color: Colors.blueAccent, height: 1),
+          data: items.value,
+          buildItem: (item, index) {
+            var person = items.value[index];
+
+            return ListItemView(person: person);
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/screens/flat_list_ex5.dart
+++ b/example/lib/screens/flat_list_ex5.dart
@@ -1,0 +1,58 @@
+import 'package:flat_list/flat_list.dart';
+import 'package:flat_list_example/common_views.dart';
+import 'package:flat_list_example/data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class FlatListEx5 extends HookWidget {
+  const FlatListEx5({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var items = useState(data);
+    var loading = useState(false);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Inverted GridView'),
+      ),
+      body: SafeArea(
+        child: FlatList(
+          numColumns: 2,
+          inverted: true,
+          loading: loading.value,
+          onEndReached: () async {
+            loading.value = true;
+            await Future.delayed(const Duration(seconds: 2));
+            if (context.mounted) {
+              items.value += getMoreData();
+              loading.value = false;
+            }
+          },
+          onRefresh: () async {
+            await Future.delayed(const Duration(seconds: 2));
+
+            if (context.mounted) {
+              items.value = data;
+            }
+          },
+          listHeaderWidget: const Header(),
+          listFooterWidget: const Footer(),
+          listEmptyWidget: Container(
+            alignment: Alignment.center,
+            padding: const EdgeInsets.all(12),
+            child: const Text('List is empty!'),
+          ),
+          // itemSeparatorWidget:
+          //     const Divider(color: Colors.blueAccent, height: 1),
+          data: items.value,
+          buildItem: (item, index) {
+            var person = items.value[index];
+
+            return ListItemView(person: person);
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/flat_list.dart
+++ b/lib/flat_list.dart
@@ -308,12 +308,12 @@ class _FlatListState<T> extends State<FlatList> {
               childCount: widget.data.length,
             ),
           ),
+          widget.listFooterWidget != null
+              ? SliverToBoxAdapter(child: widget.listFooterWidget!)
+              : const SliverToBoxAdapter(child: SizedBox()),
           widget.loading
               ? SliverToBoxAdapter(
                   child: widget.listLoadingWidget ?? defaultLoadingWidget)
-              : const SliverToBoxAdapter(child: SizedBox()),
-          widget.listFooterWidget != null
-              ? SliverToBoxAdapter(child: widget.listFooterWidget!)
               : const SliverToBoxAdapter(child: SizedBox()),
         ],
       );
@@ -336,10 +336,10 @@ class _FlatListState<T> extends State<FlatList> {
                 if (index == widget.data.length - 1) {
                   return Column(
                     children: [
-                      widget.listFooterWidget ?? const SizedBox(),
                       widget.loading
                           ? widget.listLoadingWidget ?? defaultLoadingWidget
                           : const SizedBox(),
+                      widget.listFooterWidget ?? const SizedBox(),
                       widget.itemSeparatorWidget ?? const SizedBox(),
                       widget.buildItem(item, index),
 

--- a/lib/flat_list.dart
+++ b/lib/flat_list.dart
@@ -19,6 +19,7 @@ class FlatList<T> extends StatefulWidget {
   final VoidCallback? onEndReached;
   final Function(double, double)? onScroll;
   final ScrollController? controller;
+  final bool inverted;
 
   /// Only works when [horizontal] is true.
   final int numColumns;
@@ -56,6 +57,7 @@ class FlatList<T> extends StatefulWidget {
     this.crossAxisSpacing = 10,
     this.horizontal = false,
     this.controller,
+    this.inverted = false,
   });
 
   @override
@@ -118,6 +120,7 @@ class _FlatListState<T> extends State<FlatList> {
   Widget _buildList(BuildContext context) {
     if (widget.data.isEmpty) {
       return ListView(
+        reverse: false,
         scrollDirection: widget.horizontal ? Axis.horizontal : Axis.vertical,
         children: [
           widget.listHeaderWidget ?? const SizedBox(),
@@ -150,7 +153,9 @@ class _FlatListState<T> extends State<FlatList> {
         );
       }
 
+      /// Render [GridView]
       return CustomScrollView(
+        reverse: false,
         controller: _scrollController,
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: <Widget>[
@@ -186,6 +191,7 @@ class _FlatListState<T> extends State<FlatList> {
 
     /// Render [ListView]
     return CustomScrollView(
+      reverse: false,
       scrollDirection: widget.horizontal ? Axis.horizontal : Axis.vertical,
       physics: const BouncingScrollPhysics(),
       controller: _scrollController,
@@ -237,6 +243,137 @@ class _FlatListState<T> extends State<FlatList> {
     );
   }
 
+  /// When [inverted] is true, the list will be rendered from bottom to top.
+  ///
+  /// It would be better to separate the build functions
+  /// before we actually abstract all functionalities to make code stable and clear.
+  Widget _buildInvertedList(BuildContext context) {
+    if (widget.data.isEmpty) {
+      return ListView(
+        reverse: true,
+        scrollDirection: widget.horizontal ? Axis.horizontal : Axis.vertical,
+        children: [
+          widget.listHeaderWidget ?? const SizedBox(),
+          widget.listEmptyWidget ?? const SizedBox(),
+          widget.listFooterWidget ?? const SizedBox(),
+        ],
+      );
+    }
+
+    /// Render [GridView]
+    if (widget.numColumns > 1) {
+      if (!kReleaseMode) {
+        if (widget.horizontal) {
+          throw Exception(
+              '[numColumns] is not supported with horizontal list.');
+        }
+
+        if (widget.itemSeparatorWidget != null) {
+          throw Exception(
+              '[itemSeparatorWidget] only works with [numColumn=1] list.');
+        }
+      }
+
+      if (_height == 0.0) {
+        return MeasureSize(
+          onChange: (size) {
+            setState(() => _height = size.height + 20);
+          },
+          child: widget.buildItem(widget.data[0], 0),
+        );
+      }
+
+      /// Render reversed [GridView]
+      return CustomScrollView(
+        reverse: true,
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: <Widget>[
+          widget.listHeaderWidget != null
+              ? SliverToBoxAdapter(child: widget.listHeaderWidget!)
+              : const SliverToBoxAdapter(child: SizedBox()),
+          SliverGrid(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: widget.numColumns,
+              mainAxisExtent: _height,
+              childAspectRatio: widget.childAspectRatio,
+              mainAxisSpacing: widget.mainAxisSpacing,
+              crossAxisSpacing: widget.crossAxisSpacing,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                var item = widget.data[index];
+                return widget.buildItem(item, widget.data.indexOf(item));
+              },
+              childCount: widget.data.length,
+            ),
+          ),
+          widget.loading
+              ? SliverToBoxAdapter(
+                  child: widget.listLoadingWidget ?? defaultLoadingWidget)
+              : const SliverToBoxAdapter(child: SizedBox()),
+          widget.listFooterWidget != null
+              ? SliverToBoxAdapter(child: widget.listFooterWidget!)
+              : const SliverToBoxAdapter(child: SizedBox()),
+        ],
+      );
+    }
+
+    /// Render reversed [ListView]
+    return CustomScrollView(
+      reverse: true,
+      scrollDirection: widget.horizontal ? Axis.horizontal : Axis.vertical,
+      physics: const BouncingScrollPhysics(),
+      controller: _scrollController,
+      slivers: [
+        SliverList(
+          delegate: SliverChildBuilderDelegate(
+            (context, index) {
+              var item = widget.data[index];
+
+              // The `header` and `footer` will be ignored when rendering horizontal list.
+              if (!widget.horizontal) {
+                if (index == widget.data.length - 1) {
+                  return Column(
+                    children: [
+                      widget.listFooterWidget ?? const SizedBox(),
+                      widget.loading
+                          ? widget.listLoadingWidget ?? defaultLoadingWidget
+                          : const SizedBox(),
+                      widget.itemSeparatorWidget ?? const SizedBox(),
+                      widget.buildItem(item, index),
+
+                      /// Render header widget only when the items length is 1
+                      widget.data.length == 1
+                          ? widget.listHeaderWidget ?? const SizedBox()
+                          : const SizedBox(),
+                    ],
+                  );
+                }
+
+                if (index == 0) {
+                  return Column(
+                    children: [
+                      widget.itemSeparatorWidget ?? const SizedBox(),
+                      widget.buildItem(item, index),
+                      widget.listHeaderWidget ?? const SizedBox(),
+                    ],
+                  );
+                }
+              }
+
+              return Column(children: [
+                widget.itemSeparatorWidget ?? const SizedBox(),
+                widget.buildItem(item, index),
+              ]);
+            },
+            childCount: widget.data.length,
+          ),
+        )
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (widget.onRefresh != null) {
@@ -244,9 +381,11 @@ class _FlatListState<T> extends State<FlatList> {
         onRefresh: widget.onRefresh!,
         color: widget.refreshIndicatorColor,
         strokeWidth: widget.refreshIndicatorStrokeWidth,
-        child: _buildList(context),
+        child: !widget.inverted
+            ? _buildList(context)
+            : _buildInvertedList(context),
       );
     }
-    return _buildList(context);
+    return !widget.inverted ? _buildList(context) : _buildInvertedList(context);
   }
 }


### PR DESCRIPTION
## Description 

Support [inverted](https://reactnative.dev/docs/flatlist#inverted) feature included in react-native flatlist.

This is useful when we implement lists like chatting, which loads more data by scrolling up.

## Demo

![Simulator Screen Recording - iPhone 14 - 2022-11-20 at 12 57 12](https://user-images.githubusercontent.com/27461460/202884772-ee109fe6-5386-4424-9910-f03ed6d1e379.gif)

> Demo for `inverted` list with [ListView] and [GridView]. It also works with`horizontal`.