### PR TITLE
fix: scrolls when list smaller than viewport

### DIFF
--- a/lib/flat_list.dart
+++ b/lib/flat_list.dart
@@ -165,11 +165,13 @@ class _FlatListState<T> extends State<FlatList<T>> {
     double currentScroll = _scrollController.position.pixels;
     double delta = widget.onEndReachedDelta;
 
-    return maxScroll - currentScroll <= delta && _currentSize < widget.data.length;
+    return maxScroll - currentScroll <= delta &&
+        _currentSize < widget.data.length;
   }
 
   bool _isAtEdge() {
-    return _scrollController.position.atEdge && _scrollController.position.pixels != 0;
+    return _scrollController.position.atEdge &&
+        _scrollController.position.pixels != 0;
   }
 
   @override
@@ -195,11 +197,13 @@ class _FlatListState<T> extends State<FlatList<T>> {
     if (widget.numColumns > 1) {
       if (!kReleaseMode) {
         if (widget.horizontal) {
-          throw Exception('[numColumns] is not supported with horizontal list.');
+          throw Exception(
+              '[numColumns] is not supported with horizontal list.');
         }
 
         if (widget.itemSeparatorWidget != null) {
-          throw Exception('[itemSeparatorWidget] only works with horizontal list.');
+          throw Exception(
+              '[itemSeparatorWidget] only works with horizontal list.');
         }
       }
 
@@ -241,7 +245,8 @@ class _FlatListState<T> extends State<FlatList<T>> {
               ? SliverToBoxAdapter(child: widget.listFooterWidget!)
               : const SliverToBoxAdapter(child: SizedBox()),
           widget.loading
-              ? SliverToBoxAdapter(child: widget.listLoadingWidget ?? defaultLoadingWidget)
+              ? SliverToBoxAdapter(
+                  child: widget.listLoadingWidget ?? defaultLoadingWidget)
               : const SliverToBoxAdapter(child: SizedBox()),
         ],
       );
@@ -328,11 +333,13 @@ class _FlatListState<T> extends State<FlatList<T>> {
     if (widget.numColumns > 1) {
       if (!kReleaseMode) {
         if (widget.horizontal) {
-          throw Exception('[numColumns] is not supported with horizontal list.');
+          throw Exception(
+              '[numColumns] is not supported with horizontal list.');
         }
 
         if (widget.itemSeparatorWidget != null) {
-          throw Exception('[itemSeparatorWidget] only works with [numColumn=1] list.');
+          throw Exception(
+              '[itemSeparatorWidget] only works with [numColumn=1] list.');
         }
       }
 
@@ -377,7 +384,8 @@ class _FlatListState<T> extends State<FlatList<T>> {
               ? SliverToBoxAdapter(child: widget.listFooterWidget!)
               : const SliverToBoxAdapter(child: SizedBox()),
           widget.loading
-              ? SliverToBoxAdapter(child: widget.listLoadingWidget ?? defaultLoadingWidget)
+              ? SliverToBoxAdapter(
+                  child: widget.listLoadingWidget ?? defaultLoadingWidget)
               : const SliverToBoxAdapter(child: SizedBox()),
         ],
       );
@@ -450,7 +458,9 @@ class _FlatListState<T> extends State<FlatList<T>> {
         onRefresh: widget.onRefresh!,
         color: widget.refreshIndicatorColor,
         strokeWidth: widget.refreshIndicatorStrokeWidth,
-        child: !widget.inverted ? _buildList(context) : _buildInvertedList(context),
+        child: !widget.inverted
+            ? _buildList(context)
+            : _buildInvertedList(context),
       );
     }
     return !widget.inverted ? _buildList(context) : _buildInvertedList(context);


### PR DESCRIPTION
Fixes https://github.com/hyochan/flat_list/issues/5

~~Sorry about the auto-formatting gone on.~~

I moved the logic for detecting when end has reached by creating two boolean methods and applying AlwaysScrollablePhysics to the list. The onRefresh and onEndReached events are now properly triggered for a list of any size.